### PR TITLE
WIP: Add Session validate option

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("ssl-upstream-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS upstreams")
 	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
+	flagSet.String("session-validate-url", "", "url to check if session is valid")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.StringSlice("extra-jwt-issuers", []string{}, "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -115,6 +115,7 @@ type OAuthProxy struct {
 	realClientIPParser   realClientIPParser
 	Banner               string
 	Footer               string
+	SessionValidateURL   string
 }
 
 // UpstreamProxy represents an upstream server to proxy to
@@ -323,6 +324,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		templates:            loadTemplates(opts.CustomTemplatesDir),
 		Banner:               opts.Banner,
 		Footer:               opts.Footer,
+		SessionValidateURL:   opts.SessionValidateURL,
 	}
 }
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -960,7 +960,7 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 		return nil, ErrNeedsLogin
 	}
 
-	err = p.ValidateUserSession(session)
+	err = p.ValidateUserSession(session, getClientString(p.realClientIPParser, req, false))
 	if err != nil {
 		logger.Printf("Error validating user session: %s", err)
 		return nil, ErrNeedsLogin
@@ -1077,7 +1077,7 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 }
 
 // ValidateUserSession is validating user session against session-validate-url when given
-func (p *OAuthProxy) ValidateUserSession(session *sessionsapi.SessionState) error {
+func (p *OAuthProxy) ValidateUserSession(session *sessionsapi.SessionState, remoteAddr string) error {
 	if p.SessionValidateURL == "" {
 		return nil
 	}
@@ -1088,6 +1088,7 @@ func (p *OAuthProxy) ValidateUserSession(session *sessionsapi.SessionState) erro
 	}
 	query, _ := url.ParseQuery(validateURL.RawQuery)
 	query.Set("user", session.Email)
+	query.Set("ip", remoteAddr)
 	validateURL.RawQuery = query.Encode()
 	// logger.Printf("validate-session -> %s", validateURL.String())
 

--- a/options.go
+++ b/options.go
@@ -89,6 +89,7 @@ type Options struct {
 	PassAuthorization             bool          `flag:"pass-authorization-header" cfg:"pass_authorization_header" env:"OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER"`
 	SkipAuthPreflight             bool          `flag:"skip-auth-preflight" cfg:"skip_auth_preflight" env:"OAUTH2_PROXY_SKIP_AUTH_PREFLIGHT"`
 	FlushInterval                 time.Duration `flag:"flush-interval" cfg:"flush_interval" env:"OAUTH2_PROXY_FLUSH_INTERVAL"`
+	SessionValidateURL            string        `flag:"session-validate-url" cfg:"session_validate_url" env:"OAUTH2_PROXY_SESSION_VALIDATE_URL"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.


### PR DESCRIPTION
Is adding new config option ( cli:`session-validate-url`, env: `OAUTH2_PROXY_SESSION_VALIDATE_URL` ) against what in each request is validated. GET request to this url is made with `?email=${EMAIL}&id=${IP}` add, if result is not status code 200 then request is rejected and user is send back to login page.

main logic is here 

https://github.com/eritikass/oauth2_proxy/blob/df239a79f219ce3a3be95dab6398f49c1be64dfe/oauthproxy.go#L1079-L1106